### PR TITLE
Fix access to ebay DOM by moving to content script

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,45 +1,22 @@
 let refreshIntervalId;
-let currentTabId;
+
+function loadTab(message) {
+    chrome.tabs.update(message.tabId, { url: message.url }, () => {
+        console.log('Navigated to eBay search page.');
+    });
+}
+
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    console.log('Background script received message:', message); 
+    console.log('Background script received message:', message);
 
     if (message.action === 'startSearch') {
-        console.log('Starting search for:', message.term); 
-        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-            currentTabId = tabs[0].id;
-            const searchUrl = `https://www.ebay.com/sch/i.html?_nkw=${encodeURIComponent(message.term)}&_sop=10`;
-
-            // Injecting the content script
-            chrome.scripting.executeScript({
-                target: { tabId: currentTabId },
-                files: ['contentScript.js']
-            }, (injectionResults) => {
-                if (chrome.runtime.lastError) {
-                    console.error('Content script injection failed:', chrome.runtime.lastError); 
-                } else {
-                    console.log('Content script injected successfully:', injectionResults);
-                }
-            });
-
-            // Navigate to the eBay search URL
-            chrome.tabs.update(currentTabId, { url: searchUrl }, () => {
-                console.log('Navigated to eBay search page.'); 
-                refreshIntervalId = setInterval(() => {
-                    console.log('Refreshing page...');
-                    chrome.tabs.reload(currentTabId, {}, () => {
-                        chrome.scripting.executeScript({
-                            target: { tabId: currentTabId },
-                            files: ['contentScript.js']
-                        });
-                    });
-                }, 10000);
-            });
-        });
+        loadTab(message);
+        refreshIntervalId = setInterval(() => loadTab(message), 10000);
     }
 
     if (message.action === 'stopSearch') {
-        console.log('Stopping search.'); 
+        console.log('Stopping search.');
         clearInterval(refreshIntervalId);
     }
 });

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,12 +1,12 @@
-console.log('Content script is running!'); 
+console.log('Content script is running!');
 
 function extractPrices() {
-    console.log('Extracting prices...'); 
+    console.log('Extracting prices...');
     const items = [];
     const itemContainers = document.querySelectorAll('.s-item__info');
 
     if (itemContainers.length === 0) {
-        console.error('No items found on the page. Check the selectors.'); 
+        console.error('No items found on the page. Check the selectors.');
         return;
     }
 
@@ -19,14 +19,14 @@ function extractPrices() {
                 price: price.replace(/\$/, '').trim()
             });
         } else {
-            console.warn(`Item ${index + 1} has missing name or price.`); 
+            console.warn(`Item ${index + 1} has missing name or price.`);
         }
     });
 
-    console.log('Extracted items:', items); 
+    console.log('Extracted items:', items);
     chrome.runtime.sendMessage({
         action: 'updateResults',
-        data: items.slice(0, 10) 
+        data: items.slice(0, 10)
     });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,11 @@
   "host_permissions": ["*://*.ebay.com/*"],
   "background": {
     "service_worker": "background.js"
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.ebay.com/*"],
+      "js": ["contentScript.js"]
+    }
+  ]
 }

--- a/popup.js
+++ b/popup.js
@@ -1,27 +1,37 @@
+let refreshIntervalId;
+let currentTabId;
+
 document.getElementById('searchBtn').addEventListener('click', () => {
     const searchTerm = document.getElementById('searchInput').value.trim();
-    console.log('Search button clicked. Term:', searchTerm); 
+    console.log('Search button clicked. Term:', searchTerm);
     if (searchTerm) {
-        chrome.runtime.sendMessage({ action: 'startSearch', term: searchTerm }, (response) => {
-            console.log('Message sent to background script:', response); 
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            chrome.runtime.sendMessage({
+                tabId: tabs[0].id,
+                action: 'startSearch',
+                url: `https://www.ebay.com/sch/i.html?_nkw=${encodeURIComponent(searchTerm)}&_sop=10`,
+            }, (response) => {
+                console.log('Message sent to background script:', response);
+            });
         });
+
         document.getElementById('searchBtn').style.display = 'none';
         document.getElementById('stopBtn').style.display = 'inline-block';
     } else {
-        console.log('Search term is empty.'); 
+        console.log('Search term is empty.');
     }
 });
 
 document.getElementById('stopBtn').addEventListener('click', () => {
-    console.log('Stop button clicked.'); 
-    chrome.runtime.sendMessage({ action: 'stopSearch' });
+    console.log('Stop button clicked.');
+    clearInterval(refreshIntervalId);
     document.getElementById('searchBtn').style.display = 'inline-block';
     document.getElementById('stopBtn').style.display = 'none';
 });
 
 chrome.runtime.onMessage.addListener((message) => {
     if (message.action === 'updateResults') {
-        console.log('Received results:', message.data); 
+        console.log('Received results:', message.data);
         if (message.data.length > 0) {
             document.getElementById('results').innerHTML = message.data
                 .map(item => `<div>${item.name}: $${item.price}</div>`)


### PR DESCRIPTION
Background worker has no access to target page, only content script has. Hence, manifest.js had to be adjusted. Next, background worker has no access to list of tabs apparently, so instead of worker querying tabs, popup will do it and send tab id. This has a potential advantage that there may be support for multiple instances of ebay searches running consequently (or can be easily added later - did not test this use case when creating this PR).